### PR TITLE
Drop Ruby 2.1 from CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
-  # rubocop requires ruby 2.1+ since v0.51.0
-  # https://github.com/rubocop-hq/rubocop/commit/753227914c1ad311e6116311fc1ef76d9b0904dc
-  TargetRubyVersion: 2.1
+  # rubocop requires ruby 2.2+
+  # https://github.com/rubocop-hq/rubocop/pull/5990
+  TargetRubyVersion: 2.2
 
 Metrics/BlockLength:
   Exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-- 2.1
 - 2.2
 - 2.3
 - 2.4


### PR DESCRIPTION
Ruby 2.1 will be dropped since next rubocop version
https://github.com/rubocop-hq/rubocop/pull/5990