### PR TITLE
Fix can't load `RangeHelp` error

### DIFF
--- a/rubocop-itamae.gemspec
+++ b/rubocop-itamae.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop'
+  spec.add_dependency 'rubocop', '>= 0.53.0'
 
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0.0'


### PR DESCRIPTION
I met the following error.

```
% rubocop
uninitialized constant RuboCop::Cop::Itamae::CommandEqualsToName::RangeHelp
Did you mean?  Range
/Users/katsuhiko.yoshida/.rbenv/versions/2.3.5/lib/ruby/gems/2.3.0/gems/rubocop-itamae-0.1.0/lib/rubocop/cop/itamae/command_equals_to_name.rb:21:in `<class:CommandEqualsToName>'
```

`RuboCop::Cop::Itamae::CommandEqualsToName::RangeHelp` is introduced in rubocop version 0.53.0. So, I specified version.