### PR TITLE
Require rubocop v0.69.0+ and drop support ruby < 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,6 @@
 AllCops:
-  # rubocop requires ruby 2.2+
-  # https://github.com/rubocop-hq/rubocop/pull/5990
-  TargetRubyVersion: 2.2
+  # rubocop 0.69.0+ requires ruby 2.3+
+  TargetRubyVersion: 2.3
 
 Metrics/BlockLength:
   Exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2
   - 2.3
   - 2.4
   - 2.5

--- a/lib/rubocop/cop/itamae/cd_in_execute.rb
+++ b/lib/rubocop/cop/itamae/cd_in_execute.rb
@@ -14,7 +14,7 @@ module RuboCop
       #     cwd '/tmp'
       #   end
       class CdInExecute < Cop
-        MSG = "Insert `cwd '%<dir>s'` and remove this.".freeze
+        MSG = "Insert `cwd '%<dir>s'` and remove this."
 
         def_node_search :find_execute_with_block, <<-PATTERN
           (block

--- a/lib/rubocop/cop/itamae/cd_in_execute.rb
+++ b/lib/rubocop/cop/itamae/cd_in_execute.rb
@@ -51,7 +51,7 @@ module RuboCop
         end
 
         def on_send(node)
-          return if node.parent && node.parent.block_type?
+          return if node.parent&.block_type?
 
           find_execute_without_block(node) do |name|
             add_offense_for_execute_name(node, name)

--- a/lib/rubocop/cop/itamae/command_equals_to_name.rb
+++ b/lib/rubocop/cop/itamae/command_equals_to_name.rb
@@ -21,7 +21,7 @@ module RuboCop
         include RangeHelp
 
         MSG = 'Prefer to omit `command` if `command` equals to ' \
-              'name of `execute`'.freeze
+              'name of `execute`'
 
         def_node_search :find_execute, <<-PATTERN
           (block

--- a/lib/rubocop/cop/itamae/needless_default_action.rb
+++ b/lib/rubocop/cop/itamae/needless_default_action.rb
@@ -20,7 +20,7 @@ module RuboCop
       class NeedlessDefaultAction < Cop
         include RangeHelp
 
-        MSG = 'Prefer to omit the default action.'.freeze
+        MSG = 'Prefer to omit the default action.'
 
         RESOURCE_DEFAULT_ACTIONS = {
           directory: :create,

--- a/lib/rubocop/cop/itamae/recipe_path.rb
+++ b/lib/rubocop/cop/itamae/recipe_path.rb
@@ -21,7 +21,7 @@ module RuboCop
         include RangeHelp
 
         MSG = 'Prefer recipe to placed under `cookbooks` dir' \
-              ' or `roles` dir.'.freeze
+              ' or `roles` dir.'
 
         def investigate(processed_source)
           file_path = processed_source.file_path

--- a/lib/rubocop/itamae/version.rb
+++ b/lib/rubocop/itamae/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Itamae
-    VERSION = '0.1.1'.freeze
+    VERSION = '0.1.1'
   end
 end

--- a/rubocop-itamae.gemspec
+++ b/rubocop-itamae.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '>= 11.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rubocop_auto_corrector'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'yard'
 end

--- a/rubocop-itamae.gemspec
+++ b/rubocop-itamae.gemspec
@@ -22,7 +22,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '>= 0.53.0'
+  spec.required_ruby_version = '>= 2.3.0'
+
+  spec.add_dependency 'rubocop', '>= 0.69.0'
 
   spec.add_development_dependency 'bundler', '>= 1.16'
   spec.add_development_dependency 'coveralls'


### PR DESCRIPTION
rubocop v0.69.0+ requires ruby 2.3+

https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0690-2019-05-13