### PR TITLE
`String#strip_indent` is removed since rubocop v0.75.0

### DIFF
--- a/spec/rubocop/cop/itamae/needless_default_action_spec.rb
+++ b/spec/rubocop/cop/itamae/needless_default_action_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::Itamae::NeedlessDefaultAction do
 
   context 'with default action' do
     it 'registers an offense' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         package 'git' do
           action :install
           ^^^^^^^^^^^^^^^ Prefer to omit the default action.
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::Cop::Itamae::NeedlessDefaultAction do
 
     include_examples 'autocorrect' do
       let(:original) do
-        <<-RUBY.strip_indent
+        <<~RUBY
           package 'git' do
             action :install
           end
@@ -25,7 +25,7 @@ RSpec.describe RuboCop::Cop::Itamae::NeedlessDefaultAction do
       end
 
       let(:corrected) do
-        <<-RUBY.strip_indent
+        <<~RUBY
           package 'git' do
           end
         RUBY

--- a/spec/rubocop/cop/itamae/recipe_path_spec.rb
+++ b/spec/rubocop/cop/itamae/recipe_path_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe RuboCop::Cop::Itamae::RecipePath do
     let(:filename) { '/path/to/repo/recipe.rb' }
 
     it 'registers an offense' do
-      expect_offense(<<-RUBY.strip_indent)
+      expect_offense(<<~RUBY)
         package 'git'
         ^ Prefer recipe to placed under `cookbooks` dir or `roles` dir.
       RUBY


### PR DESCRIPTION
https://github.com/rubocop-hq/rubocop/commit/87ce6e05e7583820ad66cbcb4d84615ed108fba2