### PR TITLE
Fix CI

### DIFF
--- a/rubocop-itamae.gemspec
+++ b/rubocop-itamae.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '>= 11.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rubocop', '>= 0.77.0'
   spec.add_development_dependency 'rubocop_auto_corrector'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'yard'

--- a/tasks/new_cop.rake
+++ b/tasks/new_cop.rake
@@ -20,7 +20,7 @@ task :new_cop, [:cop] do |_task, args|
 
   begin
     generator.inject_config(config_file_path: 'config/default.yml')
-  rescue TypeError # rubocop:disable Lint/HandleExceptions
+  rescue TypeError # rubocop:disable Lint/SuppressedException
     # nop
   end
 


### PR DESCRIPTION
Lint/HandleExceptions is changed to Lint/SuppressedException since rubocop 0.77.0