### PR TITLE
Requires rubocop 1.13.0+ and drop ruby 2.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,6 @@ jobs:
 
       matrix:
         ruby:
-          - ruby:2.4
           - ruby:2.5
           - ruby:2.6
           - ruby:2.7

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,8 @@
 AllCops:
   NewCops: enable
 
-  # rubocop 0.82.0+ requires ruby 2.4+
-  TargetRubyVersion: 2.4
+  # rubocop 1.13.0+ requires ruby 2.5+
+  TargetRubyVersion: 2.5
 
 Layout/LineLength:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   NewCops: enable
+  SuggestExtensions: false
 
   # rubocop 1.13.0+ requires ruby 2.5+
   TargetRubyVersion: 2.5

--- a/rubocop-itamae.gemspec
+++ b/rubocop-itamae.gemspec
@@ -22,15 +22,14 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
-  spec.add_dependency 'rubocop', '>= 0.87.0'
+  spec.add_dependency 'rubocop', '>= 1.13.0'
 
   spec.add_development_dependency 'bundler', '>= 1.16'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'rake', '>= 11.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '>= 0.84.0'
   spec.add_development_dependency 'rubocop_auto_corrector'
   spec.add_development_dependency 'simplecov', '< 0.18.0'
   spec.add_development_dependency 'yard'


### PR DESCRIPTION
Since rubocop 1.13.0, ruby 2.4 is droped.

https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#1130-2021-04-20